### PR TITLE
Turn Cifar-10 labels into binary labels

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,4 +18,5 @@ Keywords: Computer Vision
 ### References
 
 [1] Alex Krizhevsky (2009). [Learning Multiple Layers of Features from Tiny Images](https://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf).
+
 [2] Omkar M. Parkhi, Andrea Vedaldi, Andrew Zisserman, & C. V. Jawahar (2012). [Cats and Dogs](https://www.robots.ox.ac.uk/~vgg/data/pets/). In IEEE Conference on Computer Vision and Pattern Recognition.

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -21,6 +21,9 @@ class CifarDataset(Dataset):
     ))
     self.images = np.concat(self.images)
     self.labels = np.concat(self.labels)
+    # Binary label for Cat (class 3)
+    self.labels = (self.labels == 3).astype(int)
+    self.label_names = {1: "cat", 0: "other"}
 
   def __len__(self):
     return len(self.labels)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 from src.dataset import CifarDataset
 
 class TestsCifarDataset(unittest.TestCase):
@@ -6,11 +7,13 @@ class TestsCifarDataset(unittest.TestCase):
     dataset = CifarDataset()
     self.assertEqual(len(dataset), 50000, "Train size should be 50,000")
     self.assertEqual(dataset.images[0].shape, (3,32,32), "Train images should have shape 3x32x32")
+    self.assertEqual(sorted(np.unique(dataset.labels).tolist()), sorted(list(dataset.label_names.keys())))
 
   def test_init_test(self):
     dataset = CifarDataset(train=False)
     self.assertEqual(len(dataset), 10000, "Test size should be 10,000")
     self.assertEqual(dataset.images[0].shape, (3,32,32), "Test images should have shape 3x32x32")
+    self.assertEqual(sorted(np.unique(dataset.labels).tolist()), sorted(list(dataset.label_names.keys())))
     
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
# Description

Transformed the 10 classes in the Cifar-10 dataset into a binary label of 1 for Cats and 0 otherwise

# Changes

1. Changed labels into binary in `src/dataset.py`
2. Modified the corresponding unit test in `tests/test_datasets.py`
3. Added a missing newline in `Readme.md`